### PR TITLE
JNG-5543 The Optional is null when the first letter of an attribute is uppercase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 
         <judo-dao-api-version>1.0.4.20240129_105710_5ca64071_develop</judo-dao-api-version>
         <judo-meta-asm-version>1.1.4.20240208_181822_6e9e78d2_develop</judo-meta-asm-version>
-        <structured-map-proxy-version>2.0.0.20240304_134724_72ade506_develop</structured-map-proxy-version>
+        <structured-map-proxy-version>2.0.0.20240312_104112_02d952af_feature_JNG_5543_The_Optional_is_null_when_the_first_letter_of_an_attribute_is_uppercase</structured-map-proxy-version>
 
         <!--suppress UnresolvedMavenProperty -->
         <logback-test-config>${maven.multiModuleProjectDirectory}/logback-test.xml</logback-test-config>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5543" title="JNG-5543" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-5543</a>  If the first letter of an attribute name is uppercase in JSL the Optional is null in Java
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
JNG-5543 The Optional is null when the first letter of an attribute is uppercase